### PR TITLE
Use json cycle instead of decycle package

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "Sasha Koss <kossnocorp@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "json-decycle": "^1.0.0",
+    "json-cycle": "^1.0.5",
     "lodash-node": "^2.4.1",
     "redefine-test-helpers": "^0.1.0",
     "rewire-test-helpers": "1.0.0-rc2"

--- a/src/component_matchers.js
+++ b/src/component_matchers.js
@@ -1,5 +1,5 @@
 var React = require('react');
-var decycle = require('json-decycle/index').decycle;
+var decycle = require('json-cycle').decycle;
 var rewired = require('rewire-test-helpers').rewired;
 var omit = require('lodash-node/modern/objects/omit');
 


### PR DESCRIPTION
json-decycle uses ES6 structures, I don't think that adding babel-polyfil just to use this library is
good idea when we can use ES5 compatible package with the same results

What do you think?
